### PR TITLE
Remove Home header and remove extra library call

### DIFF
--- a/home/ui.R
+++ b/home/ui.R
@@ -8,7 +8,6 @@ homeUI <- function(id) {
     # Define the UI for the app
     tagList(
         fluidPage(
-            titlePanel("Home"),
             fluidRow(
                 column(12, includeMarkdown("README.md"))
             )

--- a/server.R
+++ b/server.R
@@ -8,8 +8,6 @@ library(knitr)
 library(markdown)
 library(phyloseq)
 
-library(phyloseq)
-
 # Define server logic and return the server function
 server <- function(input, output) {
     homeServer <- callModule(homeServer, "homeUI")


### PR DESCRIPTION
Removed the header for aesthetic reasons as the imported README already has a title header.